### PR TITLE
Updated Windows runner (GitHub Actions) from 2019 to 2022

### DIFF
--- a/.github/workflows/java-native-build.yml
+++ b/.github/workflows/java-native-build.yml
@@ -8,7 +8,7 @@ on:
         required: true
         default: "ubuntu-latest"
         type: choice
-        options: ['ubuntu-latest', 'macos-latest', 'windows-latest', 'ubuntu-20.04', 'macos-11', 'windows-2019']
+        options: ['ubuntu-latest', 'macos-latest', 'windows-latest', 'ubuntu-20.04', 'macos-11', 'windows-2022']
         description: "Use to select OS to build native image for."
 
 jobs:


### PR DESCRIPTION
The Windows Server 2019 runner image will be fully unsupported by June 30, 2025.

Updated 2019 runner image to 2022 on the workflow file [.github/workflows/java-native-build.yml](https://github.com/scanoss/scanoss.java/blob/92fd9d6038b21f28859d7f971e0d2f24a0107717/.github/workflows/java-native-build.yml#L11)