### PR TITLE
Change unit test flag value

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   build_and_test:
     runs-on: ubuntu-latest
+    env:
+      SCANOSS_API_KEY: ${{ secrets.SC_API_KEY }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/java-native-build.yml
+++ b/.github/workflows/java-native-build.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build_and_test:
     runs-on: ubuntu-latest
+    env:
+      SCANOSS_API_KEY: ${{ secrets.SC_API_KEY }}
     steps:
       - uses: actions/checkout@v4
 
@@ -33,6 +35,8 @@ jobs:
     needs: [ build_and_test ]
     name: Build native on ${{ github.event.inputs.build_env }}
     runs-on: ${{ github.event.inputs.build_env }}
+    env:
+      SCANOSS_API_KEY: ${{ secrets.SC_API_KEY }}
     steps:
       - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,8 @@ jobs:
   build_and_test:
     name: Build and test java code
     runs-on: ubuntu-latest
+    env:
+      SCANOSS_API_KEY: ${{ secrets.SC_API_KEY }}
     steps:
       - uses: actions/checkout@v4
 
@@ -34,7 +36,8 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USER_TOKEN }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_PWD_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PWD }}
-          
+          SCANOSS_API_KEY: ${{ secrets.SC_API_KEY }}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -73,6 +76,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+    env:
+      SCANOSS_API_KEY: ${{ secrets.SC_API_KEY }}
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,4 +154,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.12.0]: https://github.com/scanoss/scanoss.java/compare/v0.11.0...v0.12.0
 [0.12.1]: https://github.com/scanoss/scanoss.java/compare/v0.12.0...v0.12.1
 [0.13.0]: https://github.com/scanoss/scanoss.java/compare/v0.12.1...v0.13.0
-[0.13.0]: https://github.com/scanoss/scanoss.java/compare/v0.13.0...v0.13.1
+[0.13.1]: https://github.com/scanoss/scanoss.java/compare/v0.13.0...v0.13.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-03-25
+### Added
+- Added support to load a SCANOSS API key from an environment variable (`SCANOSS_API_KEY`) if available.
+
 ## [0.13.0] - 2026-02-04
 ### Added
 - Added `file_snippet` scan configuration support in `scanoss.json` for engine tuning parameters (`min_snippet_hits`, `min_snippet_lines`, `honour_file_exts`, `ranking_enabled`, `ranking_threshold`, `skip_headers`, `skip_headers_limit`)
@@ -150,3 +154,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.12.0]: https://github.com/scanoss/scanoss.java/compare/v0.11.0...v0.12.0
 [0.12.1]: https://github.com/scanoss/scanoss.java/compare/v0.12.0...v0.12.1
 [0.13.0]: https://github.com/scanoss/scanoss.java/compare/v0.12.1...v0.13.0
+[0.13.0]: https://github.com/scanoss/scanoss.java/compare/v0.13.0...v0.13.1

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.scanoss</groupId>
     <artifactId>scanoss</artifactId>
-    <version>0.13.0</version>
+    <version>0.13.1</version>
     <packaging>jar</packaging>
     <name>scanoss.java</name>
     <url>https://github.com/scanoss/scanoss.java</url>
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.20.0</version>
+            <version>1.21.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-core</artifactId>
-            <version>3.2.2</version>
+            <version>3.3.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.42</version>
+            <version>1.18.44</version>
             <optional>true</optional>
             <scope>compile</scope>
         </dependency>

--- a/src/main/java/com/scanoss/Scanner.java
+++ b/src/main/java/com/scanoss/Scanner.java
@@ -132,7 +132,7 @@ public class Scanner {
         this.timeout = timeout;
         this.retryLimit = retryLimit;
         this.url = url;
-        this.apiKey = apiKey;
+        this.apiKey = resolveApiKey(apiKey);
         this.scanFlags = scanFlags;
         this.sbomType = sbomType;
         this.sbom = sbom;
@@ -149,7 +149,7 @@ public class Scanner {
                         .skipHeadersLimit(fileSnippetConfig != null && fileSnippetConfig.getSkipHeadersLimit() != null ? fileSnippetConfig.getSkipHeadersLimit() : 0)
                         .build());
         this.scanApi = Objects.requireNonNullElseGet(scanApi, () ->
-                ScanApi.builder().url(url).apiKey(apiKey).timeout(timeout).retryLimit(retryLimit).flags(scanFlags)
+                ScanApi.builder().url(url).apiKey(this.apiKey).timeout(timeout).retryLimit(retryLimit).flags(scanFlags)
                         .sbomType(sbomType).sbom(sbom).customCert(customCert).proxy(proxy).settings(this.settings)
                         .build());
         this.scanFileProcessor = Objects.requireNonNullElseGet(scanFileProcessor, () ->
@@ -169,6 +169,28 @@ public class Scanner {
 
         this.fileFilter = Objects.requireNonNullElseGet(fileFilter , () -> FileFilterFactory.build(this.filterConfig));
         this.folderFilter = Objects.requireNonNullElseGet(folderFilter, () -> FolderFilterFactory.build(this.filterConfig));
+    }
+
+    /**
+     * Resolve the API key for Scanoss API
+     *
+     * @param apiKey The API key provided by the user
+     * @return The resolved API key, either from the user-provided value or environment variable
+     */
+    private static String resolveApiKey(String apiKey) {
+        if (apiKey != null && !apiKey.isBlank()) {
+            return apiKey;
+        }
+        try {
+            String envApiKey = System.getenv("SCANOSS_API_KEY");
+            if (envApiKey != null && !envApiKey.isBlank()) {
+                log.debug( "Using SCANOSS_API_KEY env value");
+                return envApiKey;
+            }
+        } catch (RuntimeException e) {
+            log.warn("Unable to read SCANOSS_API_KEY from environment: {}", e.getMessage());
+        }
+        return apiKey;
     }
 
     /**

--- a/src/main/java/com/scanoss/Scanner.java
+++ b/src/main/java/com/scanoss/Scanner.java
@@ -132,7 +132,7 @@ public class Scanner {
         this.timeout = timeout;
         this.retryLimit = retryLimit;
         this.url = url;
-        this.apiKey = resolveApiKey(apiKey);
+        this.apiKey = apiKey;
         this.scanFlags = scanFlags;
         this.sbomType = sbomType;
         this.sbom = sbom;
@@ -169,28 +169,6 @@ public class Scanner {
 
         this.fileFilter = Objects.requireNonNullElseGet(fileFilter , () -> FileFilterFactory.build(this.filterConfig));
         this.folderFilter = Objects.requireNonNullElseGet(folderFilter, () -> FolderFilterFactory.build(this.filterConfig));
-    }
-
-    /**
-     * Resolve the API key for Scanoss API
-     *
-     * @param apiKey The API key provided by the user
-     * @return The resolved API key, either from the user-provided value or environment variable
-     */
-    private static String resolveApiKey(String apiKey) {
-        if (apiKey != null && !apiKey.isBlank()) {
-            return apiKey;
-        }
-        try {
-            String envApiKey = System.getenv("SCANOSS_API_KEY");
-            if (envApiKey != null && !envApiKey.isBlank()) {
-                log.debug( "Using SCANOSS_API_KEY env value");
-                return envApiKey;
-            }
-        } catch (RuntimeException e) {
-            log.warn("Unable to read SCANOSS_API_KEY from environment: {}", e.getMessage());
-        }
-        return apiKey;
     }
 
     /**

--- a/src/main/java/com/scanoss/rest/ScanApi.java
+++ b/src/main/java/com/scanoss/rest/ScanApi.java
@@ -84,7 +84,7 @@ public class ScanApi {
         this.timeout = timeout;
         this.retryLimit = retryLimit;
         this.url = url;
-        this.apiKey = apiKey;
+        this.apiKey = resolveApiKey(apiKey);
         this.flags = flags;
         this.sbomType = sbomType;
         this.sbom = sbom;
@@ -128,6 +128,28 @@ public class ScanApi {
         if (!this.headers.containsKey("x-api-key") && this.apiKey != null && !this.apiKey.isEmpty()) {
             this.headers.put("x-api-key", this.apiKey);
         }
+    }
+
+    /**
+     * Resolve the API key for Scanoss API
+     *
+     * @param apiKey The API key provided by the user
+     * @return The resolved API key, either from the user-provided value or environment variable
+     */
+    private static String resolveApiKey(String apiKey) {
+        if (apiKey != null && !apiKey.isBlank()) {
+            return apiKey;
+        }
+        try {
+            String envApiKey = System.getenv("SCANOSS_API_KEY");
+            if (envApiKey != null && !envApiKey.isBlank()) {
+                log.debug( "Using SCANOSS_API_KEY env value");
+                return envApiKey;
+            }
+        } catch (RuntimeException e) {
+            log.warn("Unable to read SCANOSS_API_KEY from environment: {}", e.getMessage());
+        }
+        return apiKey;
     }
 
     /**

--- a/src/test/java/com/scanoss/TestCli.java
+++ b/src/test/java/com/scanoss/TestCli.java
@@ -133,7 +133,7 @@ public class TestCli {
         assertEquals("command should not fail", 0, exitCode);
 
         String[] args2 = new String[]{"-d", "scan", "src/test/java/com", "-T", "2", "--all-hidden",
-                "--skip-snippets", "--all-extensions", "-F", "256"
+                "--skip-snippets", "--all-extensions", "-F", "2048"
         };
         exitCode = new picocli.CommandLine(new CommandLine()).execute(args2);
         assertEquals("command should not fail", 0, exitCode);


### PR DESCRIPTION
Update unit test to use flag `-F` value that does not alter the response json structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for loading an API key from the SCANOSS_API_KEY environment variable (used when available).

* **Tests**
  * Adjusted a CLI test parameter to validate scanning with a larger chunk size.

* **Chores**
  * CI workflows now expose SCANOSS_API_KEY to relevant jobs.
  * Project version bumped to 0.13.1 and several build dependencies updated.

* **Documentation**
  * Changelog updated for v0.13.1 noting environment-key support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->