### PR TITLE
Fix: Disable OkHttp read timeout to prevent premature timeouts

### DIFF
--- a/src/main/java/com/scanoss/rest/ScanApi.java
+++ b/src/main/java/com/scanoss/rest/ScanApi.java
@@ -100,6 +100,7 @@ public class ScanApi {
         if (okHttpClient == null) {
             OkHttpClient.Builder okBuilder = new OkHttpClient.Builder();
             okBuilder.callTimeout(this.timeout);  // Set default timeout
+            okBuilder.readTimeout(Duration.ZERO);  // No read timeout; overall request is bounded by callTimeout
             // Build the HTTP client with a custom certificate (ignoring hostname verification)
             if (customCert != null && ! customCert.isEmpty()) {
                 HandshakeCertificates certificates = new HandshakeCertificates.Builder()


### PR DESCRIPTION
This change disables OkHttp's default read timeout.

Previously, OkHttp applied a default 10 second read timeout, which caused requests to fail when processing larger payloads that the SCANOSS server could not complete within that time. By disabling the read timeout, the client no longer aborts these requests prematurely, allowing long-running responses to complete successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated HTTP client configuration to remove read timeout restrictions, improving reliability for extended API operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->