### PR TITLE
chore: prepare 0.13.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.2] - 2026-07-01
+### Fixed
+- Disabled OkHttp's default read timeout so long-running scans are bounded only by the overall call timeout, preventing premature failures on large payloads.
+
 ## [0.13.1] - 2026-03-25
 ### Added
 - Added support to load a SCANOSS API key from an environment variable (`SCANOSS_API_KEY`) if available.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.scanoss</groupId>
     <artifactId>scanoss</artifactId>
-    <version>0.13.1</version>
+    <version>0.13.2</version>
     <packaging>jar</packaging>
     <name>scanoss.java</name>
     <url>https://github.com/scanoss/scanoss.java</url>


### PR DESCRIPTION
## What

Release preparation for **0.13.2**.

- Bump version `0.13.1` → `0.13.2` in `pom.xml`
- Document the OkHttp read timeout fix (from #43) in `CHANGELOG.md` under `### Fixed`

## Why

PR #43 (disable OkHttp default read timeout) was merged to `main` without a version bump or CHANGELOG entry. Because the current pom version (`0.13.1`) already has a matching tag (`v0.13.1`), `tools/get_next_version.sh` aborts and the release pipeline cannot produce a new tag. This bumps to `0.13.2` so the release can proceed.

## Release steps (after merge)

1. Merge this PR to `main`.
2. Run the **Repo Version Tagging** workflow (`workflow_dispatch`) with `run_for_real = true` → creates and pushes tag `v0.13.2`.
3. The tag push triggers **Publish** → build/test → deploy to Maven Central + native binaries + draft GitHub Release.
4. Review and publish the draft release.

## Verification

The underlying fix was verified with a MockWebServer test:
- Old client (callTimeout only) dies at ~10s on a slow read (the bug).
- PR code (`readTimeout=0`, callTimeout=60s) completes a 15s slow read successfully.
- `callTimeout` still bounds the request: with callTimeout=5s the call aborts at ~5s even with read timeout disabled (**roof timeout preserved**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for long-running scans and large payloads by preventing premature timeouts during requests.
  * Requests now complete based on the overall call timeout, reducing unexpected failures on slower operations.

* **Chores**
  * Updated the release version to **0.13.2**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->