### PR TITLE
chore: prepare 0.13.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.13.1] - 2026-03-25
+## [0.13.1] - 2026-07-01
 ### Added
 - Added support to load a SCANOSS API key from an environment variable (`SCANOSS_API_KEY`) if available.
+### Fixed
+- Disabled OkHttp's default read timeout so long-running scans are bounded only by the overall call timeout, preventing premature failures on large payloads.
 
 ## [0.13.0] - 2026-02-04
 ### Added


### PR DESCRIPTION
## What

Release preparation for **0.13.1**.

- Document the OkHttp read timeout fix (from #43) in `CHANGELOG.md` under `[0.13.1] ### Fixed`
- Set the `[0.13.1]` release date to 2026-07-01
- No `pom.xml` change: version already reads `0.13.1`

## Why

`0.13.1` was bumped in `pom.xml` and added to the CHANGELOG by an earlier change (env API key support) but **was never tagged or released** — the latest real tag and GitHub release is `v0.13.0`. Rather than jump to `0.13.2` and leave a version gap, we fold the read-timeout fix into the still-unreleased `0.13.1`. It ships both changes:

- Load SCANOSS API key from `SCANOSS_API_KEY` env var
- Disable OkHttp default read timeout (requests bounded by `callTimeout`)

`tools/get_next_version.sh` will correctly propose `v0.13.1` (latest tag `v0.13.0` ≠ pom `0.13.1`).

## Release steps (after merge)

1. Merge this PR to `main`.
2. Run the **Repo Version Tagging** workflow (`workflow_dispatch`) with `run_for_real = true` → creates and pushes tag `v0.13.1`.
3. The tag push triggers **Publish** → build/test → deploy to Maven Central + native binaries + draft GitHub Release.
4. Review and publish the draft release.

## Verification of the read-timeout fix

Verified with a MockWebServer test:
- Old client (callTimeout only) dies at ~10s on a slow read (the bug).
- Fixed code (`readTimeout=0`, callTimeout=60s) completes a 15s slow read.
- `callTimeout` still bounds the request: with callTimeout=5s the call aborts at ~5s even with read timeout disabled (**roof timeout preserved**).